### PR TITLE
feat: Implement CLI script to read and display file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Project Description
+
+This project contains Python scripts for various utilities.
+
+## `main.py`
+
+### Description
+
+The `main.py` script is a command-line utility that reads a specified file and prints its content to the standard output.
+
+### Usage
+
+You can run the script using the Python interpreter:
+
+```bash
+python main.py <filepath>
+```
+
+Alternatively, after making the script executable (e.g., `chmod +x main.py`), you can run it directly:
+
+```bash
+./main.py <filepath>
+```
+
+Replace `<filepath>` with the actual path to the file you want to read.
+
+### Example
+
+To read a file named `myfile.txt` located in the same directory as the script, you would run:
+
+```bash
+python main.py myfile.txt
+```
+
+Or, if executable:
+
+```bash
+./main.py myfile.txt
+```
+
+If the file is not found, the script will print an error message: `Error: File not found: <filepath>`.
+If no filepath is provided, `argparse` will show a usage message and exit.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+import sys # Import sys to access command-line arguments for the error message
+
+def main():
+    parser = argparse.ArgumentParser(description="Reads a file and prints its content.")
+    parser.add_argument("filepath", help="The path to the file to read.")
+    
+    # Parse arguments early to make filepath available in except block if needed
+    # However, if filepath is missing, argparse exits, so this is fine.
+    args = parser.parse_args()
+
+    try:
+        with open(args.filepath, 'r') as f:
+            content = f.read()
+            print(content)
+    except FileNotFoundError:
+        # Access the filepath directly from the parsed arguments.
+        # If parse_args() failed (e.g. no argument given), it would have exited before this point.
+        print(f"Error: File not found: {args.filepath}")
+    except Exception as e:
+        # Catch any other potential errors during file operations
+        print(f"An unexpected error occurred: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new Python script `main.py` that allows you to read and display the content of a specified file directly from the command line.

Key features:
- Takes a file path as a command-line argument.
- Reads the content of the specified file.
- Prints the file content to the console.
- Includes error handling for cases such as file not found.
- Added shebang for direct execution.

The `README.md` has also been updated to include instructions on how to use this new script.